### PR TITLE
Corrected SRSV autosave and removed ZRSV from BO and BI records

### DIFF
--- a/aravisApp/Db/aravisCamera.template
+++ b/aravisApp/Db/aravisCamera.template
@@ -59,7 +59,7 @@ record(mbbo, "$(P)$(R)ARPacketResendEnable")
    field(ONVL, "1")
    field(VAL,  "1")
    field(PINI, "1")
-   info(autosaveFields, "DESC ONSV SRSV PINI VAL")
+   info(autosaveFields, "DESC ONSV ZRSV PINI VAL")
 }
 
 record(longout, "$(P)$(R)ARPacketTimeout")
@@ -138,7 +138,7 @@ record(bi, "$(P)$(R)ARHWImageMode_RBV") {
   field(ZNAM, "No")
   field(ONAM, "Yes")
   field(SCAN, "I/O Intr")
-  info(autosaveFields, "DESC ZRSV ONSV")
+  info(autosaveFields, "DESC ONSV")
 }
 
 ## If this is set to 1, the acquisition mode is communicated to the
@@ -149,5 +149,5 @@ record(bo, "$(P)$(R)ARHWImageMode") {
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))ARAVIS_HWIMAGEMODE")
   field(ZNAM, "No")
   field(ONAM, "Yes")
-  info(autosaveFields, "DESC ZRSV ONSV VAL")
+  info(autosaveFields, "DESC ONSV VAL")
 }

--- a/aravisApp/Db/aravisCamera.template
+++ b/aravisApp/Db/aravisCamera.template
@@ -138,7 +138,7 @@ record(bi, "$(P)$(R)ARHWImageMode_RBV") {
   field(ZNAM, "No")
   field(ONAM, "Yes")
   field(SCAN, "I/O Intr")
-  info(autosaveFields, "DESC ONSV")
+  info(autosaveFields, "DESC")
 }
 
 ## If this is set to 1, the acquisition mode is communicated to the
@@ -149,5 +149,5 @@ record(bo, "$(P)$(R)ARHWImageMode") {
   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))ARAVIS_HWIMAGEMODE")
   field(ZNAM, "No")
   field(ONAM, "Yes")
-  info(autosaveFields, "DESC ONSV VAL")
+  info(autosaveFields, "DESC VAL")
 }


### PR DESCRIPTION
I've been getting autosave errors and it appears to be a typo (probably inherited from aravisGigE) in the autosave tags. There are also some BO and BI records trying to save ZRSV which i've removed.