### PR TITLE
Re-ordered includes in the main configure/RELEASE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 vendor/aravis*
 configure/*.local
+*.local
 O.*/
 bin/
 lib/

--- a/configure/RELEASE
+++ b/configure/RELEASE
@@ -2,9 +2,8 @@
 # Run "gnumake clean uninstall install" in the application
 # top directory each time this file is changed.
 
+ADGENICAM = $(AREA_DETECTOR)/ADGenICam
+
 -include $(TOP)/../configure/RELEASE_LIBS_INCLUDE
 -include $(TOP)/RELEASE.local
 -include $(TOP)/configure/RELEASE.local
-
-ADGENICAM = $(AREA_DETECTOR)/ADGenICam
-


### PR DESCRIPTION
ADGenICam is defined after "-include" directives, this would 
require modifying configure/RELEASE in case of using a site-specific
RELEASE.local. Also, added top-level *.local to .gitignore.