### PR TITLE
Aravis fixes

### DIFF
--- a/aravisApp/src/ADAravis.cpp
+++ b/aravisApp/src/ADAravis.cpp
@@ -226,6 +226,7 @@ static void aravisShutdown(void* arg) {
     arv_camera_stop_acquisition(pPvt->camera, err.get());
     pPvt->connectionValid = 0;
     epicsThreadSleep(0.1);
+    arv_stream_set_emit_signals (pPvt->stream, FALSE);
     g_clear_object(&pPvt->stream);
     g_clear_object(&pPvt->camera);
     printf("ADAravis: OK\n");

--- a/aravisApp/src/ADAravis.cpp
+++ b/aravisApp/src/ADAravis.cpp
@@ -526,6 +526,9 @@ asynStatus ADAravis::connectToCamera() {
     /* Tell areaDetector it is no longer acquiring */
     setIntegerParam(ADAcquire, 0);
 
+    /* update device list */
+    arv_update_device_list();
+
     /* make the camera object */
     status = this->makeCameraObject();
     if (status) return status;


### PR DESCRIPTION
* It destroys the *stream* object before camera object, because the ArvStream holds reference to its parent ArvDevice object. Without destroying stream object first, the device object will not be properly destroyed.
* Refresh device list before connecting.

These changes have no improvement over its current functionality but prepare the code if https://github.com/AravisProject/aravis/pull/831 will be used.